### PR TITLE
fix: change WindDirection type from int to float64

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -36,7 +36,7 @@ type CurrentWeather struct {
 	Temperature   float64
 	Time          ApiTime
 	WeatherCode   int
-	WindDirection int
+	WindDirection float64
 	WindSpeed     float64
 }
 

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -24,7 +24,7 @@ func TestForecastUnmarshalWithHourlyValues(t *testing.T) {
 		  "temperature": 13.3,
 		  "weathercode": 3,
 		  "windspeed": 10.3,
-		  "winddirection": 262
+		  "winddirection": 262.0
 		}
 	  }`)
 
@@ -57,7 +57,7 @@ func TestForecastUnmarshalWithDailyValues(t *testing.T) {
 		},
 		"daily_units": { "apparent_temperature_max": "°C" },
 		"current_weather": {
-		  "winddirection": 330,
+		  "winddirection": 330.0,
 		  "time": "2021-09-20T23:00",
 		  "temperature": 12.2,
 		  "weathercode": 3,


### PR DESCRIPTION
Hello,

I received an error like the following:
```go
json: cannot unmarshal number 169.0 into Go struct field CurrentWeather.current_weather.WindDirection of type int
```
This PR changes the WindDirection type from `int` to `float64`. 
