### PR TITLE
Add current weather to forecast

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,13 +40,20 @@ type Options struct {
 	PastDays          int      // Default 0
 	HourlyMetrics     []string // Lists required hourly metrics, see https://open-meteo.com/en/docs for valid metrics
 	DailyMetrics      []string // Lists required daily metrics, see https://open-meteo.com/en/docs for valid metrics
+	CurrentMetrics    []string // Lists required current metrics, see https://open-meteo.com/en/docs for valid metrics
 }
 
 func urlFromOptions(baseURL string, loc Location, opts *Options) string {
 	// TODO: Validate the Options are valid
-	url := fmt.Sprintf(`%s?latitude=%f&longitude=%f&current_weather=true`, baseURL, loc.lat, loc.lon)
+	url := fmt.Sprintf(`%s?latitude=%f&longitude=%f`, baseURL, loc.lat, loc.lon)
+
 	if opts == nil {
+		url = fmt.Sprintf(`%s&current_weather=true`, url)
 		return url
+	}
+
+	if opts.CurrentMetrics == nil {
+		url = fmt.Sprintf(`%s&current_weather=true`, url)
 	}
 
 	if opts.TemperatureUnit != "" {
@@ -73,6 +80,11 @@ func urlFromOptions(baseURL string, loc Location, opts *Options) string {
 	if opts.DailyMetrics != nil && len(opts.DailyMetrics) > 0 {
 		metrics := strings.Join(opts.DailyMetrics, ",")
 		url = fmt.Sprintf(`%s&daily=%s`, url, metrics)
+	}
+
+	if opts.CurrentMetrics != nil && len(opts.CurrentMetrics) > 0 {
+		metrics := strings.Join(opts.CurrentMetrics, ",")
+		url = fmt.Sprintf(`%s&current=%s`, url, metrics)
 	}
 
 	return url

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -23,13 +23,14 @@ func TestForecast(t *testing.T) {
 		PastDays:          0,
 		HourlyMetrics:     []string{"temperature_2m", "dewpoint_2m"},
 		DailyMetrics:      []string{"temperature_2m_max"},
+		CurrentMetrics:    []string{"temperature_2m", "weathercode", "windspeed_10m"},
 	}
 	res, err := c.Forecast(context.Background(), loc, &opts)
 	require.NoError(t, err)
 
-	require.False(t, res.CurrentWeather.Time.IsZero())
 	require.Greater(t, len(res.HourlyTimes), 0)
 	require.Equal(t, 2, len(res.HourlyMetrics))
 	require.Greater(t, len(res.DailyTimes), 0)
 	require.Equal(t, 1, len(res.DailyMetrics))
+	require.Equal(t, 4, len(res.CurrentMetrics))
 }

--- a/parsing.go
+++ b/parsing.go
@@ -38,6 +38,7 @@ type CurrentWeather struct {
 	WeatherCode   float64
 	WindDirection float64
 	WindSpeed     float64
+	IsDay         int `json:"is_day"`
 }
 
 // ParseBody converts the API response body into a Forecast struct


### PR DESCRIPTION
- Add is_day to current weather
- Add current weather to forecast

The reason for this PR is to enhance Forecast() api to include `current` metrics which contains more metrics than `current_weather`.