### PR TITLE
feat: add ensemble forecast support for multi-member weather prediction

### DIFF
--- a/daily_ensemble.go
+++ b/daily_ensemble.go
@@ -1,0 +1,145 @@
+package omgo
+
+import "time"
+
+// DailyEnsembleData contains daily ensemble forecast data from multiple model members.
+// Each field is a 2D slice: first dimension is the ensemble member, second is time.
+type DailyEnsembleData struct {
+	// Time contains timestamps for each day (at 00:00).
+	Times []time.Time `json:"-"`
+
+	// Temperature
+	Temperature2mMax  [][]float64 `json:"temperature_2m_max,omitempty"`
+	Temperature2mMin  [][]float64 `json:"temperature_2m_min,omitempty"`
+	Temperature2mMean [][]float64 `json:"temperature_2m_mean,omitempty"`
+
+	// Apparent temperature
+	ApparentTemperatureMax  [][]float64 `json:"apparent_temperature_max,omitempty"`
+	ApparentTemperatureMin  [][]float64 `json:"apparent_temperature_min,omitempty"`
+	ApparentTemperatureMean [][]float64 `json:"apparent_temperature_mean,omitempty"`
+
+	// Precipitation
+	PrecipitationSum   []float64 `json:"precipitation_sum,omitempty"`
+	RainSum            []float64 `json:"rain_sum,omitempty"`
+	ShowersSum         []float64 `json:"showers_sum,omitempty"`
+	SnowfallSum        []float64 `json:"snowfall_sum,omitempty"`
+	PrecipitationHours []float64 `json:"precipitation_hours,omitempty"`
+
+	// Precipitation probability
+	PrecipitationProbabilityMax  []float64 `json:"precipitation_probability_max,omitempty"`
+	PrecipitationProbabilityMin  []float64 `json:"precipitation_probability_min,omitempty"`
+	PrecipitationProbabilityMean []float64 `json:"precipitation_probability_mean,omitempty"`
+
+	// Wind
+	WindSpeed10mMax          []float64 `json:"wind_speed_10m_max,omitempty"`
+	WindGusts10mMax          []float64 `json:"wind_gusts_10m_max,omitempty"`
+	WindDirection10mDominant []float64 `json:"wind_direction_10m_dominant,omitempty"`
+
+	// Radiation (MJ/m²)
+	ShortwaveRadiationSum []float64 `json:"shortwave_radiation_sum,omitempty"`
+
+	// Evapotranspiration
+	ET0FAOEvapotranspiration []float64 `json:"et0_fao_evapotranspiration,omitempty"`
+
+	// UV Index
+	UVIndexMax         []float64 `json:"uv_index_max,omitempty"`
+	UVIndexClearSkyMax []float64 `json:"uv_index_clear_sky_max,omitempty"`
+}
+
+// MemberCount returns the number of ensemble members (first dimension of 2D arrays).
+// Returns 0 if no ensemble data is available.
+func (d *DailyEnsembleData) MemberCount() int {
+	if len(d.Temperature2mMax) > 0 {
+		return len(d.Temperature2mMax)
+	}
+	if len(d.Temperature2mMin) > 0 {
+		return len(d.Temperature2mMin)
+	}
+	if len(d.Temperature2mMean) > 0 {
+		return len(d.Temperature2mMean)
+	}
+	return 0
+}
+
+// DayCount returns the number of forecast days (second dimension).
+// Returns 0 if no data or no members.
+func (d *DailyEnsembleData) DayCount() int {
+	if len(d.Temperature2mMax) > 0 && len(d.Temperature2mMax[0]) > 0 {
+		return len(d.Temperature2mMax[0])
+	}
+	return 0
+}
+
+// CountMembersAboveThreshold counts how many members exceed the given threshold
+// for the specified metric on the specified day index.
+//
+// This is the core method for weather trading: if 20 out of 31 members
+// predict temperature > 80°F, your probability is 20/31 ≈ 64.5%.
+func (d *DailyEnsembleData) CountMembersAboveThreshold(day int, threshold float64, metric DailyMetric) int {
+	data := d.getMetric(metric)
+	if data == nil || len(data) == 0 {
+		return 0
+	}
+
+	count := 0
+	for _, member := range data {
+		if day < len(member) && member[day] > threshold {
+			count++
+		}
+	}
+	return count
+}
+
+// CountMembersBelowThreshold counts how many members are below the threshold.
+func (d *DailyEnsembleData) CountMembersBelowThreshold(day int, threshold float64, metric DailyMetric) int {
+	data := d.getMetric(metric)
+	if data == nil || len(data) == 0 {
+		return 0
+	}
+
+	count := 0
+	for _, member := range data {
+		if day < len(member) && member[day] < threshold {
+			count++
+		}
+	}
+	return count
+}
+
+// ProbabilityAbove returns the fraction of members exceeding the threshold
+// for the specified metric on the specified day (0.0 to 1.0).
+func (d *DailyEnsembleData) ProbabilityAbove(day int, threshold float64, metric DailyMetric) float64 {
+	total := d.MemberCount()
+	if total == 0 {
+		return 0.0
+	}
+	return float64(d.CountMembersAboveThreshold(day, threshold, metric)) / float64(total)
+}
+
+// ProbabilityBelow returns the fraction of members below the threshold.
+func (d *DailyEnsembleData) ProbabilityBelow(day int, threshold float64, metric DailyMetric) float64 {
+	total := d.MemberCount()
+	if total == 0 {
+		return 0.0
+	}
+	return float64(d.CountMembersBelowThreshold(day, threshold, metric)) / float64(total)
+}
+
+func (d *DailyEnsembleData) getMetric(metric DailyMetric) [][]float64 {
+	switch metric {
+	case DailyTemperature2mMax:
+		return d.Temperature2mMax
+	case DailyTemperature2mMin:
+		return d.Temperature2mMin
+	case DailyTemperature2mMean:
+		return d.Temperature2mMean
+	case DailyApparentTemperatureMax:
+		return d.ApparentTemperatureMax
+	case DailyApparentTemperatureMin:
+		return d.ApparentTemperatureMin
+	case DailyApparentTemperatureMean:
+		return d.ApparentTemperatureMean
+	default:
+		return nil
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -27,6 +27,9 @@ type rawResponse struct {
 
 	Daily      json.RawMessage `json:"daily,omitempty"`
 	DailyUnits *DailyUnits     `json:"daily_units,omitempty"`
+
+	DailyEnsemble      json.RawMessage   `json:"daily_ensemble,omitempty"`
+	DailyEnsembleUnits map[string]string `json:"daily_ensemble_units,omitempty"`
 }
 
 // rawCurrent represents the raw current weather data.
@@ -100,6 +103,7 @@ func parseWeatherResponse(body []byte) (*Weather, error) {
 		HourlyUnits:          raw.HourlyUnits,
 		Minutely15Units:      raw.Minutely15Units,
 		DailyUnits:           raw.DailyUnits,
+		DailyEnsembleUnits:   raw.DailyEnsembleUnits,
 	}
 
 	// Parse current weather
@@ -136,6 +140,15 @@ func parseWeatherResponse(body []byte) (*Weather, error) {
 			return nil, err
 		}
 		weather.Daily = daily
+	}
+
+	// Parse daily ensemble data (from /v1/ensemble)
+	if len(raw.DailyEnsemble) > 0 {
+		ensemble, err := parseDailyEnsemble(raw.DailyEnsemble, loc)
+		if err != nil {
+			return nil, err
+		}
+		weather.DailyEnsemble = ensemble
 	}
 
 	return weather, nil
@@ -261,4 +274,68 @@ func parseDaily(data json.RawMessage, loc *time.Location) (*DailyData, error) {
 	}
 
 	return daily, nil
+}
+
+// rawDailyEnsemble represents the raw API response for daily ensemble data.
+type rawDailyEnsemble struct {
+	Time                         []string    `json:"time"`
+	Temperature2mMax             [][]float64 `json:"temperature_2m_max,omitempty"`
+	Temperature2mMin             [][]float64 `json:"temperature_2m_min,omitempty"`
+	Temperature2mMean            [][]float64 `json:"temperature_2m_mean,omitempty"`
+	ApparentTemperatureMax       [][]float64 `json:"apparent_temperature_max,omitempty"`
+	ApparentTemperatureMin       [][]float64 `json:"apparent_temperature_min,omitempty"`
+	ApparentTemperatureMean      [][]float64 `json:"apparent_temperature_mean,omitempty"`
+	PrecipitationSum             []float64   `json:"precipitation_sum,omitempty"`
+	RainSum                      []float64   `json:"rain_sum,omitempty"`
+	ShowersSum                   []float64   `json:"showers_sum,omitempty"`
+	SnowfallSum                  []float64   `json:"snowfall_sum,omitempty"`
+	PrecipitationHours           []float64   `json:"precipitation_hours,omitempty"`
+	PrecipitationProbabilityMax  []float64   `json:"precipitation_probability_max,omitempty"`
+	PrecipitationProbabilityMin  []float64   `json:"precipitation_probability_min,omitempty"`
+	PrecipitationProbabilityMean []float64   `json:"precipitation_probability_mean,omitempty"`
+	WindSpeed10mMax              []float64   `json:"wind_speed_10m_max,omitempty"`
+	WindGusts10mMax              []float64   `json:"wind_gusts_10m_max,omitempty"`
+	WindDirection10mDominant     []float64   `json:"wind_direction_10m_dominant,omitempty"`
+	ShortwaveRadiationSum        []float64   `json:"shortwave_radiation_sum,omitempty"`
+	ET0FAOEvapotranspiration     []float64   `json:"et0_fao_evapotranspiration,omitempty"`
+	UVIndexMax                   []float64   `json:"uv_index_max,omitempty"`
+	UVIndexClearSkyMax           []float64   `json:"uv_index_clear_sky_max,omitempty"`
+}
+
+// parseDailyEnsemble parses ensemble daily weather data with 2D member arrays.
+func parseDailyEnsemble(data json.RawMessage, loc *time.Location) (*DailyEnsembleData, error) {
+	var raw rawDailyEnsemble
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	times, err := parseDateArray(raw.Time, loc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DailyEnsembleData{
+		Times:                        times,
+		Temperature2mMax:             raw.Temperature2mMax,
+		Temperature2mMin:             raw.Temperature2mMin,
+		Temperature2mMean:            raw.Temperature2mMean,
+		ApparentTemperatureMax:       raw.ApparentTemperatureMax,
+		ApparentTemperatureMin:       raw.ApparentTemperatureMin,
+		ApparentTemperatureMean:      raw.ApparentTemperatureMean,
+		PrecipitationSum:             raw.PrecipitationSum,
+		RainSum:                      raw.RainSum,
+		ShowersSum:                   raw.ShowersSum,
+		SnowfallSum:                  raw.SnowfallSum,
+		PrecipitationHours:           raw.PrecipitationHours,
+		PrecipitationProbabilityMax:  raw.PrecipitationProbabilityMax,
+		PrecipitationProbabilityMin:  raw.PrecipitationProbabilityMin,
+		PrecipitationProbabilityMean: raw.PrecipitationProbabilityMean,
+		WindSpeed10mMax:              raw.WindSpeed10mMax,
+		WindGusts10mMax:              raw.WindGusts10mMax,
+		WindDirection10mDominant:     raw.WindDirection10mDominant,
+		ShortwaveRadiationSum:        raw.ShortwaveRadiationSum,
+		ET0FAOEvapotranspiration:     raw.ET0FAOEvapotranspiration,
+		UVIndexMax:                   raw.UVIndexMax,
+		UVIndexClearSkyMax:           raw.UVIndexClearSkyMax,
+	}, nil
 }

--- a/request.go
+++ b/request.go
@@ -37,6 +37,9 @@ type ForecastRequest struct {
 	// Solar radiation options (for global_tilted_irradiance)
 	tilt    *float64
 	azimuth *float64
+
+	// Ensemble options
+	ensemble bool
 }
 
 // NewForecastRequest creates a new ForecastRequest for the given coordinates.
@@ -169,6 +172,19 @@ func (r *ForecastRequest) WithTilt(degrees float64) *ForecastRequest {
 func (r *ForecastRequest) WithAzimuth(degrees float64) *ForecastRequest {
 	r.azimuth = &degrees
 	return r
+}
+
+// WithEnsemble enables multi-member ensemble forecast data.
+// When enabled, the request targets the /v1/ensemble endpoint which returns
+// results from 31 model members as 2D arrays: [member][time].
+func (r *ForecastRequest) WithEnsemble() *ForecastRequest {
+	r.ensemble = true
+	return r
+}
+
+// IsEnsemble returns true if this is an ensemble forecast request.
+func (r *ForecastRequest) IsEnsemble() bool {
+	return r.ensemble
 }
 
 // HistoricalRequest represents a request to the Historical API.

--- a/url.go
+++ b/url.go
@@ -10,10 +10,15 @@ import (
 const (
 	forecastBaseURL   = "https://api.open-meteo.com/v1/forecast"
 	historicalBaseURL = "https://archive-api.open-meteo.com/v1/archive"
+	ensembleBaseURL   = "https://ensemble-api.open-meteo.com/v1/ensemble"
 )
 
 // buildURL builds the URL for a forecast request.
 func (r *ForecastRequest) buildURL(baseURL, apiKey string) string {
+	url := baseURL
+	if r.ensemble {
+		url = ensembleBaseURL
+	}
 	params := url.Values{}
 
 	// Location

--- a/url.go
+++ b/url.go
@@ -15,9 +15,9 @@ const (
 
 // buildURL builds the URL for a forecast request.
 func (r *ForecastRequest) buildURL(baseURL, apiKey string) string {
-	url := baseURL
+	target := baseURL
 	if r.ensemble {
-		url = ensembleBaseURL
+		target = ensembleBaseURL
 	}
 	params := url.Values{}
 
@@ -105,7 +105,7 @@ func (r *ForecastRequest) buildURL(baseURL, apiKey string) string {
 		params.Set("apikey", apiKey)
 	}
 
-	return baseURL + "?" + params.Encode()
+	return target + "?" + params.Encode()
 }
 
 // buildURL builds the URL for a historical request.

--- a/weather.go
+++ b/weather.go
@@ -31,4 +31,8 @@ type Weather struct {
 	// Daily data
 	Daily      *DailyData  `json:"-"` // parsed separately
 	DailyUnits *DailyUnits `json:"daily_units,omitempty"`
+
+	// Ensemble daily data (from /v1/ensemble endpoint)
+	DailyEnsemble      *DailyEnsembleData `json:"-"` // parsed separately
+	DailyEnsembleUnits map[string]string  `json:"daily_ensemble_units,omitempty"`
 }


### PR DESCRIPTION
Add WithEnsemble() method to target /v1/ensemble endpoint which returns 31 model member results as 2D arrays [member][time].

New types:
- DailyEnsembleData with [][]float64 member data
- CountMembersAboveThreshold/BelowThreshold helpers
- ProbabilityAbove/Below for direct ensemble probability calculation
- MemberCount/DayCount metadata methods

Modifies:
- request.go: ensemble bool field + WithEnsemble/IsEnsemble methods
- url.go: routes to /v1/ensemble when ensemble is enabled
- weather.go: DailyEnsemble + DailyEnsembleUnits fields
- parse.go: rawDailyEnsemble struct + parseDailyEnsemble function
- daily_ensemble.go: new file with ensemble data types